### PR TITLE
make the dockerfiles less verbose so TravisCI doesn't run out of space.

### DIFF
--- a/dockerfiles/Dockerfile.codi
+++ b/dockerfiles/Dockerfile.codi
@@ -17,8 +17,8 @@ MAINTAINER Todor Minchev <todor.minchev@linux.intel.com>
 # Build and install CODI
 RUN mkdir -p /usr/local/crops/codi/
 COPY codi /usr/local/crops/codi/
-COPY utils.* /usr/local/crops/
-COPY globals.* /usr/local/crops/
+COPY utils.[ch] /usr/local/crops/
+COPY globals.[ch] /usr/local/crops/
 
 RUN	cd /usr/local/crops/codi && \
 	make && \

--- a/dockerfiles/Dockerfile.codi.deps
+++ b/dockerfiles/Dockerfile.codi.deps
@@ -12,19 +12,19 @@ FROM ubuntu:14.04
 MAINTAINER Todor Minchev <todor.minchev@linux.intel.com>
 
 # Install dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update -qq && apt-get install -y -qq \
 	libsqlite3-dev \
 	libjansson-dev	\
 	git	\
 	wget \
 	daemontools \
 	build-essential && \
-	apt-get upgrade -y
+	apt-get upgrade -y -qq
 
 #Install a version of curl with unix sockets support
-RUN wget -P /tmp http://curl.haxx.se/download/curl-7.45.0.tar.gz && \
+RUN wget -q -P /tmp http://curl.haxx.se/download/curl-7.45.0.tar.gz && \
 	cd /tmp && \
-	tar xvf curl-7.45.0.tar.gz && \
+	tar xf curl-7.45.0.tar.gz && \
 	cd curl-7.45.0 && \
 	./configure --prefix=/usr --enable-unix-sockets && \
 	make && \

--- a/dockerfiles/Dockerfile.toolchain
+++ b/dockerfiles/Dockerfile.toolchain
@@ -27,8 +27,8 @@ ENV TOOLCHAIN_PATH http://downloads.yoctoproject.org/releases/yocto/yocto-2.0/to
 # Build and install turff
 RUN mkdir -p /usr/local/crops/turff/
 COPY turff /usr/local/crops/turff/
-COPY utils.* /usr/local/crops/
-COPY globals.* /usr/local/crops/
+COPY utils.[ch] /usr/local/crops/
+COPY globals.[ch] /usr/local/crops/
 
 RUN cd /usr/local/crops/turff && \
 	make && \
@@ -37,7 +37,7 @@ RUN cd /usr/local/crops/turff && \
 	cp /usr/local/crops/turff/turff_launcher /bin/
 
 # Download and install toolchain
-RUN wget -P /tmp ${TOOLCHAIN_PATH}${TOOLCHAIN_NAME} && \
+RUN wget -q -P /tmp ${TOOLCHAIN_PATH}${TOOLCHAIN_NAME} && \
 	cd /tmp &&	\
 	chmod 755 ./${TOOLCHAIN_NAME} &&	\
 	./${TOOLCHAIN_NAME} -d /opt/poky/ -y

--- a/dockerfiles/Dockerfile.toolchain.deps
+++ b/dockerfiles/Dockerfile.toolchain.deps
@@ -9,7 +9,7 @@ FROM ubuntu:14.04
 MAINTAINER Todor Minchev <todor.minchev@linux.intel.com>
 
 # Install dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update -qq && apt-get install -y -qq \
 	python	\
 	daemontools \
 	git \


### PR DESCRIPTION
also fix the copy util.* which fails for mac/windows

Signed-off-by: brian avery <avery.brian@gmail.com>