### PR TITLE
Add debug containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_install:
 
 script:
   - ./scripts/build_ceed
+  - docker version
   - ./scripts/build_containers
   - docker images | grep codi | grep -q test
   - docker images | grep toolchain | grep -q test

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,10 @@ compiler:
 
 before_install:
   # list docker-engine versions
-    - apt-cache madison docker-engine
+  - apt-cache madison docker-engine
+
+  # upgrade docker-engine to specific version
+  - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine=${DOCKER_VERSION}
 
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ compiler:
   - clang
 
 before_install:
+  # list docker-engine versions
+    - apt-cache madison docker-engine
 
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,14 @@ sudo: required
 services:
   - docker
 
+services:
+    - docker
+
+env:
+    global:
+        - DOCKER_VERSION=1.10.1-0~trusty
+
+
 compiler:
   - gcc
   - clang

--- a/dockerfiles/Dockerfile.codi
+++ b/dockerfiles/Dockerfile.codi
@@ -19,9 +19,10 @@ RUN mkdir -p /usr/local/crops/codi/
 COPY codi /usr/local/crops/codi/
 COPY utils.[ch] /usr/local/crops/
 COPY globals.[ch] /usr/local/crops/
+ARG build_type
 
 RUN	cd /usr/local/crops/codi && \
-	make && \
+	make $build_type && \
 	mkdir -p /bin/codi && \
 	cp /usr/local/crops/codi/codi /bin/codi/run && \
 	rm -rf /usr/local/crops

--- a/scripts/build_containers
+++ b/scripts/build_containers
@@ -20,6 +20,12 @@ if [ "$Q"  != "" ]; then
     docker rmi -f $Q
 fi
 
+Q=`docker images  -q crops/codi:testdebug`
+if [ "$Q"  != "" ]; then
+    echo "Removing codi debug image"
+    docker rmi -f $Q
+fi
+
 # remove toolchain test image as we will rebuild it
 Q=`docker images  -q crops/toolchain:test`
 if [ "$Q"  != "" ]; then
@@ -45,6 +51,9 @@ fi
 
 echo "Build CODI test image"
 docker build -t crops/codi:test -f Dockerfile.codi --rm=true ..
+
+echo "Build CODI debug test image"
+docker build -t crops/codi:testdebug --build-arg build_type=debug -f Dockerfile.codi --rm=true ..
 
 Q=`docker images  -q crops/toolchain:deps`
 if [ "$Q"  == "" ]; then

--- a/scripts/run_containers
+++ b/scripts/run_containers
@@ -18,10 +18,16 @@ if [ "$1" != "" ]; then
   NUM_TOOLCHAINS=$1
 fi
 
-echo "Start CODI container"
-docker run -d --name codi-test -v /var/run/docker.sock:/var/run/docker.sock --net=host crops/codi:test || \
-  { echo 'docker run codi failed' ; exit 1; }
 
+if [ "$DEBUG" == "" ]; then
+    echo "Start CODI container"
+    docker run -d --name codi-test -v /var/run/docker.sock:/var/run/docker.sock --net=host crops/codi:test || \
+	{ echo 'docker run codi failed' ; exit 1; }
+else
+    echo "Start DEBUG CODI container"
+    docker run -d --name codi-test-debug -v /var/run/docker.sock:/var/run/docker.sock --net=host crops/codi:testdebug || \
+	{ echo 'docker run codi failed' ; exit 1; }
+fi
 II=0
 while [ $II -lt $NUM_TOOLCHAINS ]; do
   echo "Start toolchain container $II"


### PR DESCRIPTION
This 
1) adds a codi debug container so we can run it and see the output in dockr logs
2) forces travis to use docker 1.10 so that it will build my debug container as I use a new (1.9) dockerfile syntax.